### PR TITLE
update action reference

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v3
-      - uses: devsectop/tf-via-pr@v12
+      - uses: op5dev/tf-via-pr@v13
         with:
           # Only plan by default, or apply with lock on merge.
           command: ${{ github.event_name == 'push' && 'apply' || 'plan' }}


### PR DESCRIPTION
Following name change, update references from [DevSecTop to OP5dev](https://github.com/OP5dev/TF-via-PR/releases/tag/v13.0.0).